### PR TITLE
Add missing library to lib_deps stanza.

### DIFF
--- a/emon_DB_12CT/platformio.ini
+++ b/emon_DB_12CT/platformio.ini
@@ -19,6 +19,7 @@ monitor_speed = 115200
 lib_deps =
   https://github.com/openenergymonitor/RFM69_LPL
   https://github.com/openenergymonitor/emonLibDB
+  https://github.com/openenergymonitor/emonEProm#avrdb
   https://github.com/greiman/SSD1306Ascii
 
 [env:Upload_USART]


### PR DESCRIPTION
Per discussion on OEM forum. The stock firmware fails to compile. 

This PR adds a specification for the emonEProm library to the lib_deps stanza and allows 
compilation to succeed. I am new to PlatformIO so please review for correctness.

